### PR TITLE
Can now be sourced and run as `git tableflip`

### DIFF
--- a/git-tableflip.sh
+++ b/git-tableflip.sh
@@ -1,33 +1,53 @@
 #!/bin/bash
-set -x
-set -e
+#set -x
+#set -e
 
-TABLE_FLIP_DIR="/tmp/git-table-flip"
-BASE=$(basename $PWD)
-DIR=$(dirname $PWD)
-REMOTE=$(git config --get remote.origin.url)
-TIMESTAMP=$(date +"%s")
-mkdir -p ${TABLE_FLIP_DIR}
+git-or-flip () {
+    if [ "$1" == "tableflip" ]
+    then
+        git-tableflip
+    else
+        git "$@"
+    fi
+}
 
-# if REMOTE empty exit 1
 
-# make backup
-cp -R "$PWD" "${TABLE_FLIP_DIR}/${BASE}_${TIMESTAMP}_backup"
+git-tableflip () {
+    TABLE_FLIP_DIR="/tmp/git-table-flip"
+    BASE=$(basename $PWD)
+    REMOTE=$(git config --get remote.origin.url)
+    TIMESTAMP=$(date +"%s")
 
-# if multiple table flips this will error 
-git clone "$REMOTE" "${TABLE_FLIP_DIR}/${BASE}"
+    # if REMOTE empty exit 1
+    if [[ -z "$REMOTE" ]]
+    then
+        echo "There is no remote git repository with which to flip"
+        exit 1
+    fi
 
-# remove dot gitness
-rm -rf "${PWD}/.git"
+    # make workplace
+    mkdir -p ${TABLE_FLIP_DIR}
 
-# echo tableflip emoji
+    # backup
+    cp -R "$PWD" "${TABLE_FLIP_DIR}/${BASE}_${TIMESTAMP}_backup"
 
-cp -R ${TABLE_FLIP_DIR}/${BASE}/.git ${PWD}/
+    # clone a clean version of .git files
+    git clone -q "$REMOTE" "${TABLE_FLIP_DIR}/${BASE}"
 
-# after success remove clean clone from temp
-rm -rf ${TABLE_FLIP_DIR}/${BASE}
+    # remove local dot gitness
+    rm -rf "${PWD}/.git"
 
-# echo happy strong emoji
+    # dance of the tableflip
+    echo '(╯°□°)╯︵┻━┻ '
 
-git status
+    #replace dot gitness with clean representation
+    cp -R ${TABLE_FLIP_DIR}/${BASE}/.git ${PWD}/
+
+    # after success remove clean clone from temp
+    rm -rf ${TABLE_FLIP_DIR}/${BASE}
+
+    # echo happy strong emoji
+}
+
+alias git="git-or-flip"
 


### PR DESCRIPTION
Add git-tableflip function which does the flipping and a git-or-flip function so we can alias git and only tableflip when appropriate.